### PR TITLE
fix set deregister device on beforeunload will remove previous onbeforeunload function

### DIFF
--- a/src/dai.js
+++ b/src/dai.js
@@ -151,7 +151,9 @@ export default class {
 
     // FIXME: window is not defined in node.js
     // eslint-disable-next-line func-names
-    window.onbeforeunload = () => {
+    let existingHandler = window.onbeforeunload;
+    window.onbeforeunload = (event) => {
+      if (existingHandler) existingHandler(event);
       if (this.persistentBinding) {
         return;
       }


### PR DESCRIPTION
Because windows.onbeforeunload is a callback function, when set to a new callback function, the previous callback function will be removed.